### PR TITLE
Decrease number of allocations

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -54,17 +54,14 @@ int main(const int argc, char *argv[]) {
         ip_range_list = read_from_stdin();
     }
 
-    CidrRecord *cidr_records = NULL;
-    const size_t cidr_count = merge_cidr(&ip_range_list, &cidr_records);
-    if (cidr_count > 0) {
+    ipRangeList merged_ip_range = merge_cidr(&ip_range_list);
+    freeIpRangeList(&ip_range_list);
+    const size_t total_merged_cidrs = print_ip_ranges(&merged_ip_range);
+    freeIpRangeList(&merged_ip_range);
+    if (total_merged_cidrs > 0) {
         if (options.debug) {
-            printf("DEBUG: Merged IP ranges in the CIDR format (total: %zu)\n", cidr_count);
+            printf("DEBUG: Merged IP ranges in the CIDR format (total: %zu)\n", total_merged_cidrs);
         }
-
-        for (size_t i = 0; i < cidr_count; ++i) {
-            printf("%s\n", cidr_records[i]);
-        }
-        free(*cidr_records); // Free memory
     }
 
     return 0;

--- a/src/merge.h
+++ b/src/merge.h
@@ -32,11 +32,39 @@ typedef char CidrRecord[CIDR_SIZE];
  * allocated array.
  *
  * @param cidr_list A list of C-strings representing CIDR blocks.
- * @param cidr_records A pointer to an array of `CidrRecord` where the resultant CIDR strings
- *                     will be stored. Memory for this array will be allocated by the function.
  *
  * @return The number of resulting CIDR records stored in the `cidr_records` array.
  */
-size_t merge_cidr(ipRangeList *cidr_list, CidrRecord **cidr_records);
+ipRangeList merge_cidr(const ipRangeList *cidr_list);
+
+
+
+/**
+ * @brief Writes IP ranges in CIDR notation to a file.
+ *
+ * This function iterates over an array of `ipRange` structures, converts each range
+ * into CIDR notation, and writes the CIDR blocks to the specified output file stream.
+ * It returns the total number of CIDR blocks written.
+ *
+ * @param ranges Pointer to an array of `ipRange` structures representing the IP ranges to be written.
+ * @param out The output file stream where the CIDR blocks will be written.
+ *
+ * @return The total number of CIDR blocks written to the file.
+ */
+size_t write_ip_ranges_to_file(const ipRangeList *ranges, FILE *out);
+
+
+/**
+ * @brief Prints IP ranges in CIDR notation to the standard output stream.
+ *
+ * This function is a wrapper around `write_ip_ranges_to_file` that prints the
+ * CIDR blocks to the standard output stream.
+ *
+ * @param ranges Pointer to an array of `ipRange` structures representing the IP ranges to be printed.
+ *
+ * @return The total number of CIDR blocks printed.
+ */
+size_t print_ip_ranges(const ipRangeList *ranges);
+
 
 #endif //MERGE_IP_MERGE_H

--- a/src/parse.c
+++ b/src/parse.c
@@ -181,7 +181,12 @@ ipRangeList read_from_stream(FILE *stream) {
 
         // todo: minimize number of allocations
         // Allocate memory for the temporary buffer
-        char *temp_buffer = malloc((remaining_size + buffer_len + 1) * sizeof(char));
+        char *temp_buffer = malloc(remaining_size + buffer_len + 1);
+        if (!temp_buffer) {
+            perror("Failed to allocate CIDR range temporary buffer");
+            exit(EXIT_FAILURE);
+        }
+
         if (remaining) {
             memcpy(temp_buffer, remaining, remaining_size);
         }

--- a/src/parse.c
+++ b/src/parse.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -23,6 +24,7 @@
 #include "parse.h"
 
 #define BUFFER_SIZE 1024
+#define CIDR_MAX_LENGTH 32
 
 
 /**
@@ -39,8 +41,6 @@
  *         - 3 if the subnet mask is invalid
  */
 int parse_cidr(const char *cidr, ipRange *range) {
-    const ushort CIDR_MAX_LENGTH = 32;
-
     char cidr_copy[CIDR_MAX_LENGTH];
     strncpy(cidr_copy, cidr, CIDR_MAX_LENGTH);
 
@@ -61,8 +61,9 @@ int parse_cidr(const char *cidr, ipRange *range) {
     }
 
     // compute mask
-    const u_int prefix_len = atoi(slash + 1);
-    if (prefix_len < 0 || prefix_len > CIDR_MAX_LENGTH) {
+    char *end = NULL;
+    const long prefix_len = strtol(slash + 1, &end, 10);
+    if (errno == ERANGE || prefix_len < 0 || prefix_len > CIDR_MAX_LENGTH) {
         fprintf(stderr, "ERROR: invalid network mask: %s\n", slash + 1);
         return 3; // Код помилки
     }
@@ -87,59 +88,63 @@ int parse_cidr(const char *cidr, ipRange *range) {
  *
  * @param content The input string to be parsed for CIDR blocks.
  * @param regex A precompiled regular expression to identify CIDR blocks.
+ * @param range_list A pointer to the ipRangeList structure to store the extracted CIDR blocks.
  *
  * @return A ParsedData structure containing the extracted CIDR blocks and their count.
  *
  * @note If memory allocation fails, the function prints an error message and
  *       exits the program.
  */
-ipRangeList parse_content(const char *content, const regex_t *regex) {
-    ipRangeList data = getIpRangeList(BUFFER_SIZE);
-
+void parse_content(const char *content, const regex_t *regex, ipRangeList *range_list) {
     regmatch_t matches[2];
+
     ipRange *ip_range = malloc(sizeof(ipRange));
+    if (!ip_range) {
+        perror("Failed to allocate IP range");
+        exit(EXIT_FAILURE);
+    }
+
+    char *cidr = malloc(CIDR_MAX_LENGTH);
+    if (!cidr) {
+        perror("Failed to allocate CIDR");
+        exit(EXIT_FAILURE);
+    }
+
+    char *cidr_with_prefix = malloc(CIDR_MAX_LENGTH); // 3 for "/32" and 1 for '\0'
+    if (!cidr_with_prefix) {
+        perror("Failed to allocate CIDR with prefix");
+        exit(EXIT_FAILURE);
+    }
 
     while (regexec(regex, content, 2, matches, 0) == 0) {
         const long long start = matches[1].rm_so;
         const long long end = matches[1].rm_eo;
         const long long length = end - start;
 
-        char *cidr = malloc(length + 1);
-        if (!cidr) {
-            perror("Failed to allocate CIDR");
-            exit(EXIT_FAILURE);
-        }
+        memset(cidr, 0, CIDR_MAX_LENGTH);
+        memset(cidr_with_prefix, 0, CIDR_MAX_LENGTH);
         strncpy(cidr, content + start, length);
         cidr[length] = '\0';
 
         // Add `/32` prefix for "pure" IPv4
         if (strchr(cidr, '/') == NULL) {
-            char *cidr_with_prefix = malloc(length + 4); // 3 for "/32" and 1 for '\0'
-            if (!cidr_with_prefix) {
-                perror("Failed to allocate CIDR with prefix");
-                exit(EXIT_FAILURE);
-            }
-
             if (snprintf(cidr_with_prefix, length + 4, "%s/32", cidr) != length + 3) {  // without tailing '\0'
                 perror("Failed to append CIDR prefix");
                 exit(EXIT_FAILURE);
             }
-            free(cidr);
-            cidr = cidr_with_prefix;
+            strncpy(cidr, cidr_with_prefix, length + 4);
         }
 
         if (parse_cidr(cidr, ip_range) == 0) {
-            appendIpRange(&data, ip_range);
+            appendIpRange(range_list, ip_range);
         }
-
-        free(cidr);
 
         content += end;
     }
 
+    free(cidr);
+    free(cidr_with_prefix);
     free(ip_range);
-
-    return data;
 }
 
 
@@ -182,12 +187,7 @@ ipRangeList read_from_stream(FILE *stream) {
         }
         memcpy(temp_buffer + remaining_size, buffer, buffer_len + 1);
 
-        // todo: minimize number of allocations
-        ipRangeList part_data = parse_content(temp_buffer, &regex);
-        for (size_t i = 0; i < part_data.length; ++i) {
-            appendIpRange(&overall_data, &part_data.cidrs[i]);
-        }
-        freeIpRangeList(&part_data);
+        parse_content(temp_buffer, &regex, &overall_data);
 
         // Find remaining unparsed part
         const char *last_token = temp_buffer + remaining_size + buffer_len;
@@ -196,23 +196,22 @@ ipRangeList read_from_stream(FILE *stream) {
         }
         remaining_size = temp_buffer + remaining_size + buffer_len - last_token;
 
-        remaining = realloc(remaining, remaining_size + 1);
-        if (!remaining) {
+        if ((remaining = (char *)realloc(remaining, remaining_size + 1)) == NULL) {
             perror("Failed to reallocate CIDR range buffer");
             exit(EXIT_FAILURE);
         }
+
         memcpy(remaining, last_token, remaining_size);
         remaining[remaining_size] = '\0';
 
         free(temp_buffer);
     }
 
-    if (remaining && remaining_size > 0) {
-        ipRangeList part_data = parse_content(remaining, &regex);
-        for (size_t i = 0; i < part_data.length; ++i) {
-            appendIpRange(&overall_data, &part_data.cidrs[i]);
+    if (remaining != NULL) {
+        if (remaining_size > 0) {
+            parse_content(remaining, &regex, &overall_data);
         }
-        freeIpRangeList(&part_data);
+
         free(remaining);
     }
 

--- a/tests/test_merge.c
+++ b/tests/test_merge.c
@@ -31,54 +31,73 @@
 typedef struct {
     const char **input_cidr_list;
     const size_t input_count;
-    const char **expected_cidr_list;
+    const char *expected_cidr_list;
     const size_t expected_count;
 } TestCase;
 
 
-FILE *write_to_stream(const TestCase* testCases) {
-    size_t total_length = 1;  // an empty line at the EoF
-    for (size_t item = 0; item < testCases->input_count; item++) {
-        total_length += strlen(testCases->input_cidr_list[item]) + 1; // +1 for newline
+char *get_buffer(const size_t size) {
+    char *buffer = malloc(size);
+    if (!buffer) {
+        fprintf(stderr, "Failed to allocate memory for buffer\n");
+        exit(EXIT_FAILURE);
     }
-    
-    char buffer[total_length];
-    memset(buffer, 0, sizeof(buffer));
-    
-    FILE *stream = fmemopen(buffer, sizeof(buffer), "w+");
+
+    memset(buffer, 0, size);
+    return buffer;
+}
+
+FILE *get_stream(char *buffer, const size_t size) {
+    FILE *stream = fmemopen(buffer, size, "w+");
     if (!stream) {
         perror("Failed to open memory stream");
         exit(EXIT_FAILURE);
     }
 
-    for (size_t item = 0; item < testCases->input_count; item++) {
-        fprintf(stream, "%s\n", testCases->input_cidr_list[item]);
-    }
-    fprintf(stream, "\n");  // an empty line at the EoF
-
-    rewind(stream);
     return stream;
 }
 
 
+size_t get_length(const TestCase *testCases) {
+    size_t total_length = 1;  // an empty line at the EoF
+    for (size_t item = 0; item < testCases->input_count; item++) {
+        total_length += strlen(testCases->input_cidr_list[item]) + 1; // +1 for newline
+    }
+
+    return total_length;
+}
+
+
+void write_to_stream(const TestCase* testCases, FILE *stream) {
+    for (size_t item = 0; item < testCases->input_count; item++) {
+        fprintf(stream, "%s\n", testCases->input_cidr_list[item]);
+    }
+
+    rewind(stream);
+}
+
+
+// this is not a "pure" test of the `merge_cidr()` function. It's rather a sort of integration test
+// and, therefore it should be somewhere in `test_main.c` or so
 void test_merge_cidr(void **state) {
     const TestCase test_cases[] = {
         {
             .input_cidr_list = (const char *[]){"192.168.0.0/24", "192.168.1.0/24"},
             .input_count = 2,
-            .expected_cidr_list = (const char *[]){"192.168.0.0/23"},
+            .expected_cidr_list = "192.168.0.0/23\n",
             .expected_count = 1
         },
         {
             .input_cidr_list = (const char *[]){"10.0.0.0/8", "10.1.0.0/16", "10.0.2.0/24"},
             .input_count = 3,
-            .expected_cidr_list = (const char *[]){"10.0.0.0/8"},
+            .expected_cidr_list = "10.0.0.0/8\n",
             .expected_count = 1
         },
         {
             .input_cidr_list = (const char *[]){"192.168.0.0/24", "192.168.2.0/24", "192.168.1.0/24"},
             .input_count = 3,
-            .expected_cidr_list = (const char *[]){"192.168.0.0/23", "192.168.2.0/24"},
+            .expected_cidr_list = "192.168.0.0/23\n"
+                                  "192.168.2.0/24\n",
             .expected_count = 2
         },
         {
@@ -89,14 +108,12 @@ void test_merge_cidr(void **state) {
                 "172.31.1.0/24", "192.168.100.5",
             },
             .input_count = 17,
-            .expected_cidr_list = (const char *[]){
-                "10.10.0.0/22",
-                "10.10.4.0/24",
-                "10.11.0.0/16",
-                "172.16.0.0/12",
-                "192.168.100.0/22",
-                "192.168.104.0/22",
-            },
+            .expected_cidr_list = "10.10.0.0/22\n"
+                                  "10.10.4.0/24\n"
+                                  "10.11.0.0/16\n"
+                                  "172.16.0.0/12\n"
+                                  "192.168.100.0/22\n"
+                                  "192.168.104.0/22\n",
             .expected_count = 6
         },
         {
@@ -105,12 +122,10 @@ void test_merge_cidr(void **state) {
                 "10.10.3.32/28", "10.10.3.0/25",  "10.10.4.0/24",     "10.11.0.0/16", "10.10.3.128/25",
             },
             .input_count = 11,
-            .expected_cidr_list = (const char *[]){
-                "10.10.0.0/22",
-                "10.10.4.0/24",
-                "10.11.0.0/16",
-                "192.168.100.0/22",
-            },
+            .expected_cidr_list = "10.10.0.0/22\n"
+                                  "10.10.4.0/24\n"
+                                  "10.11.0.0/16\n"
+                                  "192.168.100.0/22\n",
             .expected_count = 4
         },
         {
@@ -119,34 +134,38 @@ void test_merge_cidr(void **state) {
                 "10.10.3.32/28",  "10.10.4.0/24", "10.11.0.0/16", "10.10.3.128/25",
             },
             .input_count = 10,
-            .expected_cidr_list = (const char *[]){
-                "10.10.0.0/23",
-                "10.10.2.0/24",
-                "10.10.3.0/27",
-                "10.10.3.32/28",
-                "10.10.3.128/25",
-                "10.10.4.0/24",
-                "10.11.0.0/16",
-                "192.168.100.0/22",
-            },
+            .expected_cidr_list = "10.10.0.0/23\n"
+                                  "10.10.2.0/24\n"
+                                  "10.10.3.0/27\n"
+                                  "10.10.3.32/28\n"
+                                  "10.10.3.128/25\n"
+                                  "10.10.4.0/24\n"
+                                  "10.11.0.0/16\n"
+                                  "192.168.100.0/22\n",
             .expected_count = 8
         }
     };
 
     for (size_t i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++) {
-        FILE *stream = write_to_stream(&test_cases[i]);
+        const size_t length = get_length(&test_cases[i]);
+        char *test_cases_buffer = get_buffer(length);
+        FILE *stream = get_stream(test_cases_buffer, length);
+        write_to_stream(&test_cases[i], stream);
         ipRangeList range_list = read_from_stream(stream);
+        fclose(stream);
+        free(test_cases_buffer);
 
-        CidrRecord *cidr_records = NULL;
-        const size_t count = merge_cidr(&range_list, &cidr_records);
+        const ipRangeList merged_ip_ranges = merge_cidr(&range_list);
+
+        char *result_buffer = get_buffer(length);
+        FILE *result_stream = get_stream(result_buffer, length);
+
+        const size_t count = write_ip_ranges_to_file(&merged_ip_ranges, result_stream);
+        fclose(result_stream);
 
         assert_int_equal(count, test_cases[i].expected_count);
+        assert_string_equal(result_buffer, test_cases[i].expected_cidr_list);
 
-        for (size_t j = 0; j < test_cases[i].expected_count; j++) {
-            assert_string_equal(cidr_records[j], test_cases[i].expected_cidr_list[j]);
-        }
-
-        free(cidr_records);
-        fclose(stream);
+        free(result_buffer);
     }
 }


### PR DESCRIPTION
CHANGES:
 - Allocations in the `parse_content()` is optimized;
 - An extra check is added to the `read_from_stream()`;
 - An extra buffer/variable is removed from the `merge_cidr()`. The `merge_cidr()` now just merges adjacent ranges and returns them "as is". A couple of special functions are added to output the result:
    - `write_ip_ranges_to_file()`;
    - `print_ip_ranges()`