### PR TITLE
Fix bug with `fread`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,9 +16,7 @@
 file(GLOB HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
 file(GLOB SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.c")
 
-if (CMAKE_BUILD_TYPE STREQUAL "Release")
-    add_definitions(-Ofast)
-elseif (CMAKE_BUILD_TYPE STREQUAL "Asan")
+if (CMAKE_BUILD_TYPE STREQUAL "Asan")
     add_definitions(
             -g
             -O1

--- a/src/cli.c
+++ b/src/cli.c
@@ -20,6 +20,8 @@
 
 #include "cli.h"
 
+#include "main.h"
+
 /**
  * @brief Prints the usage message for the program.
  *
@@ -31,7 +33,8 @@
  */
 void print_usage(const char *program_name) {
     printf(
-            "Usage: %s [-f filename | --file=filename] [-d | --debug] [-h | --help]\n"
+            "Usage: %s [-f filename | --file=filename] [-d | --debug] [-h | --help] "
+            "[-v | --version]\n"
             "\nThe program takes CIDRs from the input (stdin or given file), sorts them,\n"
             "removes duplicates, merges adjacent blocks into one continuous sequence and\n"
             "prints result\n"
@@ -41,7 +44,8 @@ void print_usage(const char *program_name) {
             "                       input (stdin).\n"
             "  -d, --debug          Enables debug mode, printing additional debug\n"
             "                       information during execution.\n"
-            "  -h, --help           Displays this help message and exits.\n",
+            "  -h, --help           Displays this help message and exits.\n"
+            "  -v, --version        Displays the program version and exits.\n",
             program_name
     );
 }
@@ -77,6 +81,9 @@ CommandLineOptions parse_command_line_options(int argc, char *argv[]) {
             options.debug = true;
         } else if ((strcmp(argv[i], "-f") == 0 && i + 1 < argc) || strncmp(argv[i], "--file=", 7) == 0) {
             options.file = (strcmp(argv[i], "-f") == 0) ? argv[++i] : argv[i] + 7;
+        } else if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--version") == 0) {
+            printf("%s version %s\n", PROGRAM_NAME, VERSION);
+            exit(0);
         } else {
             fprintf(stderr, "Unknown option or incorrect usage.\n");
             print_usage(argv[0]);

--- a/src/main.h
+++ b/src/main.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#define VERSION "0.0.1"
+#define VERSION "0.0.2"
 #define PROGRAM_NAME "merge-ip"
 #define PROGRAM_COPYRIGHT "Copyright 2024 Yurii Havenchuk"
 #define PROGRAM_LICENSE "Apache License, Version 2.0"

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -20,18 +20,26 @@
 #include <cmocka.h>
 
 void test_parse_command_line_options(void **state);
+void test_empty_data_set(void **state);
+void test_noise_data_set(void **state);
 void test_merge_cidr_separated_by_new_line(void **state);
 void test_merge_cidr_separated_by_space(void **state);
 void test_merge_cidr_separated_by_tab(void **state);
-void test_merge_cidr_separated_by_page(void **state);
+void test_reading_buffer_captures_only_host_part_of_tailing_cidr(void **state);
+void test_reading_buffer_captures_broken_part_of_tailing_cidr(void **state);
+void test_reading_buffer_captures_oly_part_of_tailing_cidr_prefix(void **state);
 
 int main(void) {
     const struct CMUnitTest tests[] = {
             cmocka_unit_test(test_parse_command_line_options),
+            cmocka_unit_test(test_empty_data_set),
+            cmocka_unit_test(test_noise_data_set),
             cmocka_unit_test(test_merge_cidr_separated_by_new_line),
             cmocka_unit_test(test_merge_cidr_separated_by_space),
             cmocka_unit_test(test_merge_cidr_separated_by_tab),
-            cmocka_unit_test(test_merge_cidr_separated_by_page),
+            cmocka_unit_test(test_reading_buffer_captures_only_host_part_of_tailing_cidr),
+            cmocka_unit_test(test_reading_buffer_captures_broken_part_of_tailing_cidr),
+            cmocka_unit_test(test_reading_buffer_captures_oly_part_of_tailing_cidr_prefix),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -19,13 +19,19 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-void test_merge_cidr(void **state);
 void test_parse_command_line_options(void **state);
+void test_merge_cidr_separated_by_new_line(void **state);
+void test_merge_cidr_separated_by_space(void **state);
+void test_merge_cidr_separated_by_tab(void **state);
+void test_merge_cidr_separated_by_page(void **state);
 
 int main(void) {
     const struct CMUnitTest tests[] = {
-            cmocka_unit_test(test_merge_cidr),
             cmocka_unit_test(test_parse_command_line_options),
+            cmocka_unit_test(test_merge_cidr_separated_by_new_line),
+            cmocka_unit_test(test_merge_cidr_separated_by_space),
+            cmocka_unit_test(test_merge_cidr_separated_by_tab),
+            cmocka_unit_test(test_merge_cidr_separated_by_page),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/test_merge.c
+++ b/tests/test_merge.c
@@ -36,6 +36,72 @@ typedef struct {
 } TestCase;
 
 
+const TestCase test_cases[] = {
+    {
+        .input_cidr_list = (const char *[]){"192.168.0.0/24", "192.168.1.0/24"},
+        .input_count = 2,
+        .expected_cidr_list = "192.168.0.0/23\n",
+        .expected_count = 1
+    },
+    {
+        .input_cidr_list = (const char *[]){"10.0.0.0/8", "10.1.0.0/16", "10.0.2.0/24"},
+        .input_count = 3,
+        .expected_cidr_list = "10.0.0.0/8\n",
+        .expected_count = 1
+    },
+    {
+        .input_cidr_list = (const char *[]){"192.168.0.0/24", "192.168.2.0/24", "192.168.1.0/24"},
+        .input_count = 3,
+        .expected_cidr_list = "192.168.0.0/23\n"
+                              "192.168.2.0/24\n",
+        .expected_count = 2
+    },
+    {
+        .input_cidr_list = (const char *[]){
+            "10.10.0.0/24",  "10.10.1.0/24",  "192.168.100.0/22", "10.10.2.0/24",     "10.10.3.0/28",
+            "10.10.3.16/28", "10.10.3.32/28", "172.31.0.0/16",    "10.10.3.0/25",     "10.10.4.0/24",
+            "10.11.0.0/16",  "172.31.1.1",    "10.10.3.128/25",   "192.168.104.0/22", "172.16.0.0/12",
+            "172.31.1.0/24", "192.168.100.5",
+        },
+        .input_count = 17,
+        .expected_cidr_list = "10.10.0.0/22\n"
+                              "10.10.4.0/24\n"
+                              "10.11.0.0/16\n"
+                              "172.16.0.0/12\n"
+                              "192.168.100.0/22\n"
+                              "192.168.104.0/22\n",
+        .expected_count = 6
+    },
+    {
+        .input_cidr_list = (const char *[]){
+            "10.10.0.0/24",  "10.10.1.0/24",  "192.168.100.0/22", "10.10.2.0/24", "10.10.3.0/28",   "10.10.3.16/28",
+            "10.10.3.32/28", "10.10.3.0/25",  "10.10.4.0/24",     "10.11.0.0/16", "10.10.3.128/25",
+        },
+        .input_count = 11,
+        .expected_cidr_list = "10.10.0.0/22\n"
+                              "10.10.4.0/24\n"
+                              "10.11.0.0/16\n"
+                              "192.168.100.0/22\n",
+        .expected_count = 4
+    },
+    {
+        .input_cidr_list = (const char *[]){
+            "10.10.0.0/24",  "10.10.1.0/24",  "192.168.100.0/22", "10.10.2.0/24", "10.10.3.0/28",   "10.10.3.16/28",
+            "10.10.3.32/28",  "10.10.4.0/24", "10.11.0.0/16", "10.10.3.128/25",
+        },
+        .input_count = 10,
+        .expected_cidr_list = "10.10.0.0/23\n"
+                              "10.10.2.0/24\n"
+                              "10.10.3.0/27\n"
+                              "10.10.3.32/28\n"
+                              "10.10.3.128/25\n"
+                              "10.10.4.0/24\n"
+                              "10.11.0.0/16\n"
+                              "192.168.100.0/22\n",
+        .expected_count = 8
+    }
+};
+
 char *get_buffer(const size_t size) {
     char *buffer = malloc(size);
     if (!buffer) {
@@ -47,7 +113,7 @@ char *get_buffer(const size_t size) {
     return buffer;
 }
 
-FILE *get_stream(char *buffer, const size_t size) {
+FILE *get_memory_stream(char *buffer, const size_t size) {
     FILE *stream = fmemopen(buffer, size, "w+");
     if (!stream) {
         perror("Failed to open memory stream");
@@ -58,114 +124,116 @@ FILE *get_stream(char *buffer, const size_t size) {
 }
 
 
-size_t get_length(const TestCase *testCases) {
+typedef struct TestDataStream {
+    char *buffer;
+    FILE *stream;
+} TestDataStream;
+
+void open_stream(TestDataStream* stream, const size_t length) {
+    stream->buffer = get_buffer(length);
+    stream->stream = get_memory_stream(stream->buffer, length);
+}
+
+void close_stream(const TestDataStream* stream) {
+    fclose(stream->stream);
+    free(stream->buffer);
+}
+
+void write_to_stream(const TestDataStream* stream, const TestCase* test_case, const char* separator) {
+    for (size_t item = 0; item < test_case->input_count; item++) {
+        fprintf(stream->stream, "%s%s", test_case->input_cidr_list[item], separator);
+    }
+
+    rewind(stream->stream);
+}
+
+
+size_t get_length(const TestCase *testCases, const char* separator) {
     size_t total_length = 1;  // an empty line at the EoF
     for (size_t item = 0; item < testCases->input_count; item++) {
         total_length += strlen(testCases->input_cidr_list[item]) + 1; // +1 for newline
     }
 
-    return total_length;
+    return total_length + strlen(separator) * testCases->input_count;
 }
 
+typedef struct MergedTestCase {
+    const size_t count;
+    const char* result;
+} MergedTestCase;
 
-void write_to_stream(const TestCase* testCases, FILE *stream) {
-    for (size_t item = 0; item < testCases->input_count; item++) {
-        fprintf(stream, "%s\n", testCases->input_cidr_list[item]);
-    }
+MergedTestCase merge_test_case(const TestCase* test_case, const char* separator) {
+    const size_t max_buffer_length = get_length(test_case, separator);
 
-    rewind(stream);
+    TestDataStream data_stream;
+    open_stream(&data_stream, max_buffer_length);
+    write_to_stream(&data_stream, test_case, separator);
+
+    const ipRangeList *range_list = read_from_stream(data_stream.stream);
+    close_stream(&data_stream);
+
+    const ipRangeList *merged_ip_ranges = merge_cidr(range_list);
+
+    TestDataStream result_stream;
+    open_stream(&result_stream, max_buffer_length);
+
+    const size_t count = write_ip_ranges_to_file(merged_ip_ranges, result_stream.stream);
+    fclose(result_stream.stream);
+
+    return (MergedTestCase){
+        .count = count,
+        .result = result_stream.buffer
+    };
 }
 
 
 // this is not a "pure" test of the `merge_cidr()` function. It's rather a sort of integration test
 // and, therefore it should be somewhere in `test_main.c` or so
-void test_merge_cidr(void **state) {
-    const TestCase test_cases[] = {
-        {
-            .input_cidr_list = (const char *[]){"192.168.0.0/24", "192.168.1.0/24"},
-            .input_count = 2,
-            .expected_cidr_list = "192.168.0.0/23\n",
-            .expected_count = 1
-        },
-        {
-            .input_cidr_list = (const char *[]){"10.0.0.0/8", "10.1.0.0/16", "10.0.2.0/24"},
-            .input_count = 3,
-            .expected_cidr_list = "10.0.0.0/8\n",
-            .expected_count = 1
-        },
-        {
-            .input_cidr_list = (const char *[]){"192.168.0.0/24", "192.168.2.0/24", "192.168.1.0/24"},
-            .input_count = 3,
-            .expected_cidr_list = "192.168.0.0/23\n"
-                                  "192.168.2.0/24\n",
-            .expected_count = 2
-        },
-        {
-            .input_cidr_list = (const char *[]){
-                "10.10.0.0/24",  "10.10.1.0/24",  "192.168.100.0/22", "10.10.2.0/24",     "10.10.3.0/28",
-                "10.10.3.16/28", "10.10.3.32/28", "172.31.0.0/16",    "10.10.3.0/25",     "10.10.4.0/24",
-                "10.11.0.0/16",  "172.31.1.1",    "10.10.3.128/25",   "192.168.104.0/22", "172.16.0.0/12",
-                "172.31.1.0/24", "192.168.100.5",
-            },
-            .input_count = 17,
-            .expected_cidr_list = "10.10.0.0/22\n"
-                                  "10.10.4.0/24\n"
-                                  "10.11.0.0/16\n"
-                                  "172.16.0.0/12\n"
-                                  "192.168.100.0/22\n"
-                                  "192.168.104.0/22\n",
-            .expected_count = 6
-        },
-        {
-            .input_cidr_list = (const char *[]){
-                "10.10.0.0/24",  "10.10.1.0/24",  "192.168.100.0/22", "10.10.2.0/24", "10.10.3.0/28",   "10.10.3.16/28",
-                "10.10.3.32/28", "10.10.3.0/25",  "10.10.4.0/24",     "10.11.0.0/16", "10.10.3.128/25",
-            },
-            .input_count = 11,
-            .expected_cidr_list = "10.10.0.0/22\n"
-                                  "10.10.4.0/24\n"
-                                  "10.11.0.0/16\n"
-                                  "192.168.100.0/22\n",
-            .expected_count = 4
-        },
-        {
-            .input_cidr_list = (const char *[]){
-                "10.10.0.0/24",  "10.10.1.0/24",  "192.168.100.0/22", "10.10.2.0/24", "10.10.3.0/28",   "10.10.3.16/28",
-                "10.10.3.32/28",  "10.10.4.0/24", "10.11.0.0/16", "10.10.3.128/25",
-            },
-            .input_count = 10,
-            .expected_cidr_list = "10.10.0.0/23\n"
-                                  "10.10.2.0/24\n"
-                                  "10.10.3.0/27\n"
-                                  "10.10.3.32/28\n"
-                                  "10.10.3.128/25\n"
-                                  "10.10.4.0/24\n"
-                                  "10.11.0.0/16\n"
-                                  "192.168.100.0/22\n",
-            .expected_count = 8
-        }
-    };
+void test_merge_cidr_separated_by_new_line(void **state) {
+    for (size_t i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++) {
+        const MergedTestCase merged_test_case = merge_test_case(&test_cases[i], "\n");
+
+        assert_int_equal(merged_test_case.count, test_cases[i].expected_count);
+        assert_string_equal(merged_test_case.result, test_cases[i].expected_cidr_list);
+
+        free((void*)merged_test_case.result);
+    }
+}
+
+void test_merge_cidr_separated_by_space(void **state) {
+    for (size_t i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++) {
+        const MergedTestCase merged_test_case = merge_test_case(&test_cases[i], " ");
+
+        assert_int_equal(merged_test_case.count, test_cases[i].expected_count);
+        assert_string_equal(merged_test_case.result, test_cases[i].expected_cidr_list);
+
+        free((void*)merged_test_case.result);
+    }
+}
+
+void test_merge_cidr_separated_by_tab(void **state) {
+    for (size_t i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++) {
+        const MergedTestCase merged_test_case = merge_test_case(&test_cases[i], "\t");
+
+        assert_int_equal(merged_test_case.count, test_cases[i].expected_count);
+        assert_string_equal(merged_test_case.result, test_cases[i].expected_cidr_list);
+
+        free((void*)merged_test_case.result);
+    }
+}
+
+void test_merge_cidr_separated_by_page(void **state) {
+    const unsigned int page_size = 1000;
+    char empty_page[page_size];
+    memset(empty_page, ' ', page_size - 1);
+    empty_page[page_size - 1] = '\0';
 
     for (size_t i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++) {
-        const size_t length = get_length(&test_cases[i]);
-        char *test_cases_buffer = get_buffer(length);
-        FILE *stream = get_stream(test_cases_buffer, length);
-        write_to_stream(&test_cases[i], stream);
-        const ipRangeList *range_list = read_from_stream(stream);
-        fclose(stream);
-        free(test_cases_buffer);
+        const MergedTestCase merged_test_case = merge_test_case(&test_cases[i], empty_page);
 
-        const ipRangeList *merged_ip_ranges = merge_cidr(range_list);
+        assert_int_equal(merged_test_case.count, test_cases[i].expected_count);
+        assert_string_equal(merged_test_case.result, test_cases[i].expected_cidr_list);
 
-        char *result_buffer = get_buffer(length);
-        FILE *result_stream = get_stream(result_buffer, length);
-
-        const size_t count = write_ip_ranges_to_file(merged_ip_ranges, result_stream);
-        fclose(result_stream);
-
-        assert_int_equal(count, test_cases[i].expected_count);
-        assert_string_equal(result_buffer, test_cases[i].expected_cidr_list);
-
-        free(result_buffer);
+        free((void*)merged_test_case.result);
     }
 }


### PR DESCRIPTION
In case the read buffer captured a meaningful part of the CIDR block (host, host + part of prefix) near its end it might lead to bugs, due to the wrong interpretation of the data. 

For example, we had some input data, that ended with `... 192.168.1.0/24`, and because of the limited size of the reading buffer, it might captured something like `... 192.168.1.0` or `... 192.168.1.0/2`, which changes the meaning of the CIDR. 

Now parser checks if there's a valid CIDR at the end of the buffer without tailing spaces and if so, skips that data for the next round of reading.