### PR TITLE
Fix #2 for the partial capture of a CIDR

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#define VERSION "0.0.2"
+#define VERSION "0.0.3"
 #define PROGRAM_NAME "merge-ip"
 #define PROGRAM_COPYRIGHT "Copyright 2024 Yurii Havenchuk"
 #define PROGRAM_LICENSE "Apache License, Version 2.0"

--- a/src/parse.c
+++ b/src/parse.c
@@ -28,8 +28,8 @@
 #define BUFFER_SIZE 1024
 // strlen("255.255.255.255/255.255.255.255") + '\0'
 #define CIDR_MAX_LENGTH 32  // 3 for "/32" and 1 for '\0'
-// strlen("1.1.1.1/0") + '\0'
-#define CIDR_MIN_LENGTH 10
+// strlen("1.1.1.1")
+#define CIDR_MIN_LENGTH 7
 // The buffer may contain a limited number of records. In the limiting case there cannot be more than
 // ceil(BUFFER_SIZE / (CIDR_MIN_LENGTH + 1) )
 // Here:
@@ -172,7 +172,7 @@ size_t parse_content(const char *content, const regex_t *regex, ipRangeList *ran
         const size_t token_end = matches[5].rm_eo; // position of the last matched token (CIDR + whitespaces)
         parsed_length += token_end;
 
-        if (ignore_tails && parsed_length == content_length && !isspace(content[cidr_end])) {
+        if (ignore_tails && parsed_length >= content_length - CIDR_MIN_LENGTH && !isspace(content[cidr_end])) {
             parsed_length += cidr_start - token_end;
             break;
         }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -27,7 +27,7 @@ void test_merge_cidr_separated_by_space(void **state);
 void test_merge_cidr_separated_by_tab(void **state);
 void test_reading_buffer_captures_only_host_part_of_tailing_cidr(void **state);
 void test_reading_buffer_captures_broken_part_of_tailing_cidr(void **state);
-void test_reading_buffer_captures_oly_part_of_tailing_cidr_prefix(void **state);
+void test_reading_buffer_captures_only_part_of_tailing_cidr_prefix(void **state);
 
 int main(void) {
     const struct CMUnitTest tests[] = {
@@ -39,7 +39,7 @@ int main(void) {
             cmocka_unit_test(test_merge_cidr_separated_by_tab),
             cmocka_unit_test(test_reading_buffer_captures_only_host_part_of_tailing_cidr),
             cmocka_unit_test(test_reading_buffer_captures_broken_part_of_tailing_cidr),
-            cmocka_unit_test(test_reading_buffer_captures_oly_part_of_tailing_cidr_prefix),
+            cmocka_unit_test(test_reading_buffer_captures_only_part_of_tailing_cidr_prefix),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/test_merge.c
+++ b/tests/test_merge.c
@@ -352,12 +352,13 @@ void test_reading_buffer_captures_only_host_part_of_tailing_cidr(void **state) {
 }
 
 void test_reading_buffer_captures_broken_part_of_tailing_cidr(void **state) {
-    // i.e. something like "192.168." or "192.168.1.0/" - those values
+    // i.e. something like "192.168.0." or "192.168.1.0/" - those values
     // for sure cannot be considered as valid CIDRs
-    merge_cidr_separated_by_page(1000);
+    merge_cidr_separated_by_page(1000); // 192.168.1.
+    merge_cidr_separated_by_page(998);  // 192.168.1.0/
 }
 
-void test_reading_buffer_captures_oly_part_of_tailing_cidr_prefix(void **state) {
+void test_reading_buffer_captures_only_part_of_tailing_cidr_prefix(void **state) {
     // attempt to emulate case when due to buffer size a reading loop
     // cuts only part of the prefix in the last CIDR block, in other words
     // the prefix contains 2 digits, but buffer caught only first one
@@ -365,5 +366,5 @@ void test_reading_buffer_captures_oly_part_of_tailing_cidr_prefix(void **state) 
     // assuming buffer size is `1024`, we need to put 1001 symbols as a
     // separator between CIDRs
     // BUFFER_SIZE - strlen("192.168.0.0/24") + strlen("192.168.1.0/2") == 999
-    merge_cidr_separated_by_page(1001);
+    merge_cidr_separated_by_page(997);
 }


### PR DESCRIPTION
This time it fixes case when the reading buffer splits CIDR right by the slash (`/`) in result we have something like `192.168.1.0/`