### PR TITLE
Add `gcc` compiler support to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         build_type: [ Release ]
-        c_compiler: [ clang ]
+        c_compiler: [ clang, gcc ]
         include:
           - os: ubuntu-latest
             c_compiler: clang

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 .idea/*
-cmake-build-debug/*
-cmake-build-release/*
-cmake-build-asan/*
+cmake-build*
 toolchains/openwrt/build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ project(merge-ip C)
 set(CMAKE_C_STANDARD 11)
 
 enable_testing()
-add_link_options(-lm)
 add_subdirectory(src)
 add_subdirectory(tests)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,3 +42,11 @@ else ()
 endif()
 
 add_executable(merge-ip ${HEADERS} ${SOURCES})
+
+include(CheckFunctionExists)
+CHECK_FUNCTION_EXISTS(log2 HAS_LOG2)
+CHECK_FUNCTION_EXISTS(fmin HAS_FMIN)
+
+if(NOT HAS_LOG2 OR NOT HAS_FMIN)
+    target_link_libraries(merge-ip PRIVATE m)
+endif()

--- a/src/parse.c
+++ b/src/parse.c
@@ -52,22 +52,18 @@
  *         - 3 if the subnet mask is invalid
  */
 int parse_cidr(const char *cidr, ipRange *range) {
-    char cidr_copy[CIDR_MAX_LENGTH];
-    strncpy(cidr_copy, cidr, CIDR_MAX_LENGTH);
-
     // split CIDR to IP & mask
-    char *slash = strchr(cidr_copy, '/');
+    char *slash = strchr(cidr, '/');
     if (slash == NULL) {
-        // if there's no prefix add /32
-        strncat(cidr_copy, "/32", sizeof(cidr_copy) - strlen(cidr_copy) - 1);
-        slash = strchr(cidr_copy, '/');
+        perror("CIDR without prefix! It should've never happened! I'm going to die now!");
+        exit(EXIT_FAILURE);
     }
     *slash = '\0';
 
     // convert IP address to binary format
     struct in_addr ip;
-    if (inet_aton(cidr_copy, &ip) == 0) {
-        fprintf(stderr, "ERROR: invalid IP address: %s\n", cidr_copy);
+    if (inet_aton(cidr, &ip) == 0) {
+        fprintf(stderr, "ERROR: invalid IP address: %s\n", cidr);
         return 2; // Error code
     }
 
@@ -76,7 +72,7 @@ int parse_cidr(const char *cidr, ipRange *range) {
     const long prefix_len = strtol(slash + 1, &end, 10);
     if (errno == ERANGE || prefix_len < 0 || prefix_len > CIDR_MAX_LENGTH) {
         fprintf(stderr, "ERROR: invalid network mask: %s\n", slash + 1);
-        return 3; // Код помилки
+        return 3; // Error code
     }
 
     // compute minimal & maximal IP-address
@@ -115,10 +111,10 @@ bool is_host(const char* cidr) {
 void add_prefix(char* cidr) {
     const unsigned char length = (unsigned char)strlen(cidr); // max CIDR length is 32, which is less than 255
 
-    cidr[length + 1] = '/';
-    cidr[length + 2] = '3';
-    cidr[length + 3] = '2';
-    cidr[length + 4] = 0;
+    cidr[length] = '/';
+    cidr[length + 1] = '3';
+    cidr[length + 2] = '2';
+    cidr[length + 3] = 0;
 }
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,14 @@ list(REMOVE_ITEM SOURCES "${PROJECT_SOURCE_DIR}/src/main.c")
 target_include_directories(merge-ip_tests PRIVATE ${PROJECT_SOURCE_DIR}/src)
 target_link_libraries(merge-ip_tests PRIVATE cmocka::cmocka ${SOURCES})
 
+include(CheckFunctionExists)
+CHECK_FUNCTION_EXISTS(log2 HAS_LOG2)
+CHECK_FUNCTION_EXISTS(fmin HAS_FMIN)
+
+if(NOT HAS_LOG2 OR NOT HAS_FMIN)
+    target_link_libraries(merge-ip_tests PRIVATE m)
+endif()
+
 add_test(NAME merge-ip_tests COMMAND merge-ip_tests)
 
 # Additional test options


### PR DESCRIPTION
 - Fix `parse_cidr()` and `ensure_prefix()`
 - Add check if `log2` & `fmin` functions exists and if not - add `m` library trough `target_link_libraries()`