### PR TITLE
Add windows-latest to the matrix strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-latest ]
+        os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
         build_type: [ Release ]
         c_compiler: [ clang, gcc ]
 
@@ -55,4 +55,4 @@ jobs:
         working-directory: ${{ steps.strings.outputs.build-output-dir }}
         # Execute tests defined by the CMake configuration.
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-        run: ctest -R merge-ip_tests --output-on-failure -V
+        run: ctest -C ${{ matrix.build_type }} -R merge-ip_tests --output-on-failure -V

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.31)
 project(merge-ip C)
 
 set(CMAKE_C_STANDARD 11)
+
+include(CheckFunctionExists)
+CHECK_FUNCTION_EXISTS(log2 HAS_LOG2)
+CHECK_FUNCTION_EXISTS(fmin HAS_FMIN)
+
+if(WIN32)
+    find_package(PCRE QUIET)
+
+    if (NOT PCRE_FOUND)
+        message(STATUS "PCRE not found, downloading...")
+
+        include(FetchContent)
+
+        set(PCRE2_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+        set(PCRE2_BUILD_PCRE2POSIX ON CACHE BOOL "" FORCE)
+
+        FetchContent_Declare(
+                PCRE
+                GIT_REPOSITORY https://github.com/PCRE2Project/pcre2.git
+                GIT_TAG pcre2-10.45
+        )
+        FetchContent_MakeAvailable(pcre)
+    endif()
+endif()
+
 
 enable_testing()
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,37 +16,36 @@
 file(GLOB HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
 file(GLOB SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.c")
 
+add_definitions(-Wall)
+
 if (CMAKE_BUILD_TYPE STREQUAL "Asan")
     add_definitions(
-            -g
             -O1
-            -Wno-unused-parameter
             -Wall
-            -Werror
-            -Wextra
-            -fno-omit-frame-pointer
             -fsanitize=address
             -fsanitize=integer
             -fsanitize=undefined
     )
     add_link_options(-fsanitize=address -fsanitize=integer -fsanitize=undefined)
-else ()
-    add_definitions(
-        -g
-        -Wno-unused-parameter
-        -Wall
-        -Werror
-        -Wextra
-        -fno-omit-frame-pointer
-    )
 endif()
+
+if(NOT WIN32)
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_definitions(-g -fno-omit-frame-pointer)
+    endif()
+
+    add_definitions(-Wno-unused-parameter -Werror -Wextra)
+endif ()
+
 
 add_executable(merge-ip ${HEADERS} ${SOURCES})
 
-include(CheckFunctionExists)
-CHECK_FUNCTION_EXISTS(log2 HAS_LOG2)
-CHECK_FUNCTION_EXISTS(fmin HAS_FMIN)
 
 if(NOT HAS_LOG2 OR NOT HAS_FMIN)
     target_link_libraries(merge-ip PRIVATE m)
+endif()
+
+if(WIN32)
+    target_link_libraries(merge-ip PRIVATE pcre2-posix)
+    target_link_libraries(merge-ip PRIVATE ws2_32)
 endif()

--- a/src/ipRange.c
+++ b/src/ipRange.c
@@ -64,7 +64,7 @@ ipRangeList *getIpRangeList(const size_t size) {
  * @param data Pointer to ipRangeList structure whose memory
  *             needs to be freed.
  */
-inline void freeIpRangeList(ipRangeList *data) {
+void freeIpRangeList(ipRangeList *data) {
     if (data->cidrs != NULL) {
         free(data->cidrs);
         data->cidrs = NULL;

--- a/src/ipRange.h
+++ b/src/ipRange.h
@@ -17,7 +17,12 @@
 #ifndef IPRANGE_H
 #define IPRANGE_H
 
-#include <arpa/inet.h>
+#ifdef _WIN32
+  #include <winsock2.h>
+  #include <ws2tcpip.h>
+#else
+  #include <arpa/inet.h>
+#endif
 
 // A struct to store minimal and maximal IPs
 typedef struct {

--- a/src/main.c
+++ b/src/main.c
@@ -39,6 +39,14 @@
  * @return int Returns 0 on successful execution.
  */
 int main(const int argc, char *argv[]) {
+    #ifdef _WIN32
+        WSADATA wsa;
+        if (WSAStartup(MAKEWORD(2,2), &wsa) != 0) {
+            fprintf(stderr, "WSAStartup failed\n");
+            return 1;
+        }
+    #endif
+
     const CommandLineOptions options = parse_command_line_options(argc, argv);
     ipRangeList *ip_range_list = NULL;
 
@@ -63,6 +71,10 @@ int main(const int argc, char *argv[]) {
             printf("DEBUG: Merged IP ranges in the CIDR format (total: %zu)\n", total_merged_cidrs);
         }
     }
+
+    #ifdef _WIN32
+        WSACleanup();
+    #endif
 
     return 0;
 }

--- a/src/main.h
+++ b/src/main.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#define VERSION "0.0.4"
+#define VERSION "0.0.5"
 #define PROGRAM_NAME "merge-ip"
 #define PROGRAM_COPYRIGHT "Copyright 2024 Yurii Havenchuk"
 #define PROGRAM_LICENSE "Apache License, Version 2.0"

--- a/src/merge.c
+++ b/src/merge.c
@@ -16,9 +16,10 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <arpa/inet.h>
 #include <math.h>
+#ifdef _WIN32
+    #include <stdint.h>
+#endif
 
 #include "merge.h"
 

--- a/src/merge.h
+++ b/src/merge.h
@@ -17,6 +17,8 @@
 #ifndef MERGE_IP_MERGE_H
 #define MERGE_IP_MERGE_H
 
+#include <stdio.h>
+
 #include "ipRange.h"
 
 #define CIDR_SIZE 20

--- a/src/parse.c
+++ b/src/parse.c
@@ -21,7 +21,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
-#include <regex.h>
+
+#ifdef _WIN32
+    #include <stdint.h>
+    #include <pcre2posix.h>
+#else
+    #include <regex.h>
+#endif
 
 #include "parse.h"
 
@@ -62,7 +68,7 @@ int parse_cidr(const char *cidr, ipRange *range) {
 
     // convert IP address to binary format
     struct in_addr ip;
-    if (inet_aton(cidr, &ip) == 0) {
+    if (inet_pton(AF_INET, cidr, &ip) != 1) {
         fprintf(stderr, "ERROR: invalid IP address: %s\n", cidr);
         return 2; // Error code
     }
@@ -304,6 +310,6 @@ ipRangeList *read_from_file(const char *filename) {
  * @return A ParsedData structure containing the parsed CIDR blocks and their
  *         count.
  */
-inline ipRangeList *read_from_stdin() {
+ipRangeList* read_from_stdin() {
     return read_from_stream(stdin);
 }

--- a/src/parse.h
+++ b/src/parse.h
@@ -17,6 +17,8 @@
 #ifndef MERGE_IP_PARSE_H
 #define MERGE_IP_PARSE_H
 
+#include <stdio.h>
+
 #include "ipRange.h"
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,9 @@
 
 # FetchContent to download CMocka
 include(FetchContent)
+
+set(CMAKE_DISABLE_TESTING ON) # Disable building CMocka's tests
+
 FetchContent_Declare(
     cmocka
     GIT_REPOSITORY https://git.cryptomilk.org/projects/cmocka.git
@@ -22,33 +25,33 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(cmocka)
 
-# Enable CTest
-include(CTest)
-
 # Test sources
 file(GLOB TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/test_*.c")
+file(GLOB SOURCES "${PROJECT_SOURCE_DIR}/src/*.c")
+file(GLOB HEADERS "${PROJECT_SOURCE_DIR}/src/*.h")
+list(REMOVE_ITEM SOURCES "${PROJECT_SOURCE_DIR}/src/main.c")
+
 add_executable(
         merge-ip_tests
         test_main.c
         ${TEST_SOURCES}
+        ${SOURCES}
+        ${HEADERS}
 )
 
-# Link original source files
-file(GLOB SOURCES "${PROJECT_SOURCE_DIR}/src/*.c")
-list(REMOVE_ITEM SOURCES "${PROJECT_SOURCE_DIR}/src/main.c")
-
 target_include_directories(merge-ip_tests PRIVATE ${PROJECT_SOURCE_DIR}/src)
-target_link_libraries(merge-ip_tests PRIVATE cmocka::cmocka ${SOURCES})
+target_link_libraries(merge-ip_tests PRIVATE cmocka::cmocka )
 
-include(CheckFunctionExists)
-CHECK_FUNCTION_EXISTS(log2 HAS_LOG2)
-CHECK_FUNCTION_EXISTS(fmin HAS_FMIN)
 
 if(NOT HAS_LOG2 OR NOT HAS_FMIN)
     target_link_libraries(merge-ip_tests PRIVATE m)
 endif()
 
-add_test(NAME merge-ip_tests COMMAND merge-ip_tests)
+if(WIN32)
+    target_link_libraries(merge-ip_tests PRIVATE pcre2-posix)
+    target_link_libraries(merge-ip_tests PRIVATE ws2_32)
+endif()
 
-# Additional test options
-add_custom_target(tests COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure)
+# Enable CTest
+include(CTest)
+add_test(NAME merge-ip_tests COMMAND merge-ip_tests)

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -19,6 +19,12 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
+#ifdef _WIN32
+  #include <stdio.h>
+  #include <winsock2.h>
+  #include <ws2tcpip.h>
+#endif
+
 void test_parse_command_line_options(void **state);
 void test_empty_data_set(void **state);
 void test_noise_data_set(void **state);
@@ -30,6 +36,14 @@ void test_reading_buffer_captures_broken_part_of_tailing_cidr(void **state);
 void test_reading_buffer_captures_only_part_of_tailing_cidr_prefix(void **state);
 
 int main(void) {
+    #ifdef _WIN32
+        WSADATA wsa;
+        if (WSAStartup(MAKEWORD(2,2), &wsa) != 0) {
+            fprintf(stderr, "WSAStartup failed\n");
+            return 1;
+        }
+    #endif
+
     const struct CMUnitTest tests[] = {
             cmocka_unit_test(test_parse_command_line_options),
             cmocka_unit_test(test_empty_data_set),
@@ -42,5 +56,11 @@ int main(void) {
             cmocka_unit_test(test_reading_buffer_captures_only_part_of_tailing_cidr_prefix),
     };
 
-    return cmocka_run_group_tests(tests, NULL, NULL);
+    const int tests_result = cmocka_run_group_tests(tests, NULL, NULL);
+
+    #ifdef _WIN32
+        WSACleanup();
+    #endif
+
+    return tests_result;
 }


### PR DESCRIPTION
In the scope of this change:
  - move compiler options  `-g`, `-Wno-unused-parameter`, `-Werror`, `-Wextra`, and
   `-fno-omit-frame-pointer` to  non-windows OS;
  - add PCRE in Windows systems to support regex;
  - replacing `<arpa/inet.h>` with `<ws2tcpip.h>` in WIN systems;
  - add WIN sockets initialization to tests;
  - remove `<regex>` from `test_merge.c`;
  - remove redundant imports in tests;
  - define `uint32_t` for WIN systems
  - explicitly set a build type for tests (required in Windows)
  - fix tests for WIN systems: in WIN there's no `fmemopen()`, so we have to use
    real files (temporary, but in the file system instead of memory);