### PR TITLE
Enhance CMake configuration and CI for cross-platform testing 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,18 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
         build_type: [ Release ]
-        c_compiler: [ clang, gcc ]
+        c_compiler: [ clang, gcc, cl ]
+        exclude:
+          - os: ubuntu-latest
+            c_compiler: cl
+          - os: macos-13
+            c_compiler: cl
+          - os: macos-latest
+            c_compiler: cl
+          - os: windows-latest
+            c_compiler: gcc
+          - os: windows-latest
+            c_compiler: clang
 
     steps:
       - uses: actions/checkout@v4

--- a/cmake-modules/CMakeLists.txt
+++ b/cmake-modules/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Yurii Havenchuk.
+# Copyright 2025 Yurii Havenchuk.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.31)
-project(merge-ip C)
+file(GLOB_RECURSE CMAKE_MODULES CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/*.cmake")
 
-set(CMAKE_C_STANDARD 11)
-
-add_subdirectory(cmake-modules)
-add_subdirectory(src)
-add_subdirectory(tests)
-
-enable_testing()
-message(STATUS "CMake project setup complete. Ready to build and run tests.")
+foreach(module ${CMAKE_MODULES})
+    include(${module})
+    message(DEBUG "Included CMake module: ${module}")
+endforeach()

--- a/cmake-modules/EnableCMocka.cmake
+++ b/cmake-modules/EnableCMocka.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Yurii Havenchuk.
+# Copyright 2025 Yurii Havenchuk.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.31)
-project(merge-ip C)
+function(enable_cmocka target)
+    set(CMAKE_DISABLE_TESTING ON) # Disable building CMocka's tests
 
-set(CMAKE_C_STANDARD 11)
+    # FetchContent to download CMocka
+    include(FetchContent)
 
-add_subdirectory(cmake-modules)
-add_subdirectory(src)
-add_subdirectory(tests)
+    FetchContent_Declare(
+            cmocka
+            GIT_REPOSITORY https://git.cryptomilk.org/projects/cmocka.git
+            GIT_TAG        cmocka-1.1.7
+    )
+    FetchContent_MakeAvailable(cmocka)
 
-enable_testing()
-message(STATUS "CMake project setup complete. Ready to build and run tests.")
+    target_link_libraries(${target} PRIVATE cmocka::cmocka)
+endfunction()

--- a/cmake-modules/EnablePortableMath.cmake
+++ b/cmake-modules/EnablePortableMath.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Yurii Havenchuk.
+# Copyright 2025 Yurii Havenchuk.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.31)
-project(merge-ip C)
+function(enable_portable_math target)
+    include(CheckFunctionExists)
 
-set(CMAKE_C_STANDARD 11)
+    check_function_exists(log2 HAS_LOG2)
+    check_function_exists(fmin HAS_FMIN)
 
-add_subdirectory(cmake-modules)
-add_subdirectory(src)
-add_subdirectory(tests)
-
-enable_testing()
-message(STATUS "CMake project setup complete. Ready to build and run tests.")
+    if(NOT HAS_LOG2 OR NOT HAS_FMIN)
+        target_link_libraries(${target} PRIVATE m)
+    endif()
+endfunction()

--- a/cmake-modules/EnableRegexFallback.cmake
+++ b/cmake-modules/EnableRegexFallback.cmake
@@ -1,0 +1,40 @@
+#
+# Copyright 2025 Yurii Havenchuk.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function(enable_regex_fallback target)
+    if(NOT WIN32)
+        return()
+    endif()
+
+    find_package(PCRE QUIET)
+
+    if (NOT PCRE_FOUND)
+        message(STATUS "PCRE2 not found — fetching fallback POSIX-compatible regex support...")
+
+        include(FetchContent)
+
+        set(PCRE2_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+        set(PCRE2_BUILD_PCRE2POSIX ON CACHE BOOL "" FORCE)
+
+        FetchContent_Declare(
+                PCRE
+                GIT_REPOSITORY https://github.com/PCRE2Project/pcre2.git
+                GIT_TAG        pcre2-10.45
+        )
+        FetchContent_MakeAvailable(PCRE)
+    endif()
+
+    target_link_libraries(${target} PRIVATE pcre2-posix ws2_32)
+endfunction()

--- a/cmake-modules/OptimizeBuildFlags.cmake
+++ b/cmake-modules/OptimizeBuildFlags.cmake
@@ -1,0 +1,86 @@
+#
+# Copyright 2025 Yurii Havenchuk.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function(enable_optimized_build_flags target)
+    if(NOT TARGET ${target})
+        message(FATAL_ERROR "Target '${target}' does not exist.")
+    endif()
+
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+            target_compile_options(${target} PRIVATE
+                    -g
+                    -fno-omit-frame-pointer
+                    -fsanitize=address
+                    -fsanitize=integer
+                    -fsanitize=leak
+                    -fsanitize=memory
+                    -fsanitize=pointer
+                    -fsanitize=safestack
+                    -fsanitize=undefined
+            )
+            target_link_options(${target} PRIVATE
+                    -fsanitize=address
+                    -fsanitize=integer
+                    -fsanitize=leak
+                    -fsanitize=memory
+                    -fsanitize=pointer
+                    -fsanitize=safestack
+                    -fsanitize=undefined
+            )
+        endif()
+    elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
+        if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+            # ==== Safety ====
+            target_compile_options(${target} PRIVATE
+                    -fstack-protector-strong
+                    -fstack-clash-protection
+                    -D_FORTIFY_SOURCE=2
+            )
+
+            # ==== Memory ====
+            target_compile_options(${target} PRIVATE
+                    -ffunction-sections
+                    -fdata-sections
+                    -fno-common
+            )
+            target_link_options(${target} PRIVATE
+                    -Wl,
+                    --gc-sections
+            )
+
+            # ==== Performance ====
+            target_compile_options(${target} PRIVATE
+                    -O3
+                    -march=native
+                    -mtune=native
+            )
+        elseif(MSVC)
+            target_compile_options(${target} PRIVATE
+                    /O2        # performance
+                    /GL        # Whole Program Optimization
+                    /Gw        # Global variable optimization
+            )
+            target_link_options(${target} PRIVATE
+                    /LTCG      # Link Time Code Generation
+                    /OPT:REF   # Remove unused code
+                    /OPT:ICF   # Combining identical functions
+            )
+        endif()
+    endif()
+
+    # ==== Enabling LTO ====
+    set_target_properties(${target} PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+endfunction()

--- a/cmake-modules/StrictCompileFlags.cmake
+++ b/cmake-modules/StrictCompileFlags.cmake
@@ -58,7 +58,6 @@ function(enable_strict_build_flags target_name)
         set(strict_compile_flags
                 /W4
                 /permissive-
-                /sdl
         )
     endif()
 

--- a/cmake-modules/StrictCompileFlags.cmake
+++ b/cmake-modules/StrictCompileFlags.cmake
@@ -59,7 +59,6 @@ function(enable_strict_build_flags target_name)
                 /W4
                 /permissive-
                 /sdl
-                /analyze
         )
     endif()
 

--- a/cmake-modules/StrictCompileFlags.cmake
+++ b/cmake-modules/StrictCompileFlags.cmake
@@ -58,6 +58,7 @@ function(enable_strict_build_flags target_name)
         set(strict_compile_flags
                 /W4
                 /permissive-
+                /analyze
         )
     endif()
 

--- a/cmake-modules/StrictCompileFlags.cmake
+++ b/cmake-modules/StrictCompileFlags.cmake
@@ -57,7 +57,6 @@ function(enable_strict_build_flags target_name)
         message(STATUS "Using MSVC warnings")
         set(strict_compile_flags
                 /W4
-                /WX
                 /permissive-
                 /sdl
                 /analyze

--- a/cmake-modules/StrictCompileFlags.cmake
+++ b/cmake-modules/StrictCompileFlags.cmake
@@ -1,0 +1,68 @@
+#
+# Copyright 2025 Yurii Havenchuk.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function(enable_strict_build_flags target_name)
+    if(NOT TARGET ${target_name})
+        message(FATAL_ERROR "Target '${target_name}' not found.")
+    endif()
+
+    set(strict_compile_flags "")
+
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        message(STATUS "Using GCC warnings")
+        set(strict_compile_flags
+                -Wall
+                -Wextra
+                -Werror
+                -Wpedantic
+                -Wshadow
+                -Wconversion
+                -Wnull-dereference
+                -Wdouble-promotion
+                -Wformat=2
+                -fanalyzer
+        )
+
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        message(STATUS "Using Clang warnings")
+        set(strict_compile_flags
+                -Wall
+                -Wextra
+                -Werror
+                -Wpedantic
+                -Wshadow
+                -Wconversion
+                -Wnull-dereference
+                -Wdouble-promotion
+                -Wformat=2
+                -Weverything
+                -Wno-c++98-compat
+                -Wno-c++98-compat-pedantic
+                -Wno-disabled-macro-expansion
+        )
+
+    elseif(MSVC)
+        message(STATUS "Using MSVC warnings")
+        set(strict_compile_flags
+                /W4
+                /WX
+                /permissive-
+                /sdl
+                /analyze
+        )
+    endif()
+
+    target_compile_options(${target_name} PRIVATE ${strict_compile_flags})
+endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,36 +16,9 @@
 file(GLOB HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
 file(GLOB SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.c")
 
-add_definitions(-Wall)
-
-if (CMAKE_BUILD_TYPE STREQUAL "Asan")
-    add_definitions(
-            -O1
-            -Wall
-            -fsanitize=address
-            -fsanitize=integer
-            -fsanitize=undefined
-    )
-    add_link_options(-fsanitize=address -fsanitize=integer -fsanitize=undefined)
-endif()
-
-if(NOT WIN32)
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-        add_definitions(-g -fno-omit-frame-pointer)
-    endif()
-
-    add_definitions(-Wno-unused-parameter -Werror -Wextra)
-endif ()
-
-
 add_executable(merge-ip ${HEADERS} ${SOURCES})
 
-
-if(NOT HAS_LOG2 OR NOT HAS_FMIN)
-    target_link_libraries(merge-ip PRIVATE m)
-endif()
-
-if(WIN32)
-    target_link_libraries(merge-ip PRIVATE pcre2-posix)
-    target_link_libraries(merge-ip PRIVATE ws2_32)
-endif()
+enable_strict_build_flags(merge-ip)
+enable_optimized_build_flags(merge-ip)
+enable_portable_math(merge-ip)
+enable_regex_fallback(merge-ip)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,18 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# FetchContent to download CMocka
-include(FetchContent)
-
-set(CMAKE_DISABLE_TESTING ON) # Disable building CMocka's tests
-
-FetchContent_Declare(
-    cmocka
-    GIT_REPOSITORY https://git.cryptomilk.org/projects/cmocka.git
-    GIT_TAG        cmocka-1.1.7
-)
-FetchContent_MakeAvailable(cmocka)
-
 # Test sources
 file(GLOB TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/test_*.c")
 file(GLOB SOURCES "${PROJECT_SOURCE_DIR}/src/*.c")
@@ -40,17 +28,12 @@ add_executable(
 )
 
 target_include_directories(merge-ip_tests PRIVATE ${PROJECT_SOURCE_DIR}/src)
-target_link_libraries(merge-ip_tests PRIVATE cmocka::cmocka )
 
-
-if(NOT HAS_LOG2 OR NOT HAS_FMIN)
-    target_link_libraries(merge-ip_tests PRIVATE m)
-endif()
-
-if(WIN32)
-    target_link_libraries(merge-ip_tests PRIVATE pcre2-posix)
-    target_link_libraries(merge-ip_tests PRIVATE ws2_32)
-endif()
+enable_cmocka(merge-ip_tests)
+enable_strict_build_flags(merge-ip_tests)
+enable_optimized_build_flags(merge-ip_tests)
+enable_portable_math(merge-ip_tests)
+enable_regex_fallback(merge-ip_tests)
 
 # Enable CTest
 include(CTest)


### PR DESCRIPTION
- added support for custom CMake modules (see `cmake-modules` directory);
- `CMocka`, `math`, and `regex` libraries are extracted into separate modules;
- Compiler and linker flags for optimization and sanitization are extracted into separate CMake modules.
- GitHub CI explicitly uses only the `cl` compiler for the `windows-latest` OS.